### PR TITLE
Specify #includes in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=
 category=Data Processing
 url=https://github.com/arduino-libraries/Arduino_CRC32
 architectures=*
+includes=Arduino_CRC32.h


### PR DESCRIPTION
This prevents **Sketch > Include Library > Arduino_CRC32** from cluttering the sketch with an `#include` directive for crc.h.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format