### PR TITLE
Use GitHub Actions for Continuous Integration

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,29 @@
+name: Compile Examples
+on: [push, pull_request]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   strategy:
+     matrix:
+       fqbn: [
+         "arduino:samd:mkr1000",
+         "arduino:samd:mkrzero",
+         "arduino:samd:mkrwifi1010",
+         "arduino:samd:mkrfox1200",
+         "arduino:samd:mkrwan1300",
+         "arduino:samd:mkrwan1310",
+         "arduino:samd:mkrgsm1400",
+         "arduino:samd:mkrnb1500",
+         "arduino:samd:mkrvidor4000",
+         "arduino:samd:arduino_zero_edbg",
+         "arduino:samd:nano_33_iot"
+       ]
+
+   steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: arduino/actions/libraries/compile-examples@master
+       with:
+         fqbn: ${{ matrix.fqbn }}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,11 @@
+name: Spell Check
+on: [push, pull_request]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+
+   steps:
+     - uses: actions/checkout@v1
+       with:
+         fetch-depth: 1
+     - uses: arduino/actions/libraries/spell-check@master

--- a/src/crc.h
+++ b/src/crc.h
@@ -15,7 +15,7 @@
  *
  * This file defines the functions crc_init(), crc_update() and crc_finalize().
  *
- * The crc_init() function returns the inital \c crc value and must be called
+ * The crc_init() function returns the initial \c crc value and must be called
  * before the first call to crc_update().
  * Similarly, the crc_finalize() function must be called after the last call
  * to crc_update(), before the \c crc is being used.


### PR DESCRIPTION
- Compile example sketches for SAMD boards.
- Spell check all files.

Successful CI run: https://github.com/per1234/Arduino_CRC32/runs/377349986