### PR TITLE
Reduce AVR RAM by 1K, with maybe slight reduction in Flash ROM

### DIFF
--- a/src/crc.cpp
+++ b/src/crc.cpp
@@ -16,13 +16,13 @@
 #include "crc.h"     /* include the header file generated with pycrc */
 #include <stdlib.h>
 #include <stdint.h>
-#ifdef CRC32_AVR_FLASH_TABLE
+#ifdef ARDUINO_ARCH_AVR
 #include <avr/pgmspace.h>
 #endif
 /**
  * Static table used for the table_driven implementation.
  */
-#ifdef CRC32_AVR_FLASH_TABLE
+#ifdef ARDUINO_ARCH_AVR
 static const PROGMEM crc_t crc_table[256] = {
 #else
 static const crc_t crc_table[256] = {
@@ -69,7 +69,7 @@ crc_t crc_update(crc_t crc, const void *data, size_t data_len)
 
     while (data_len--) {
         tbl_idx = (crc ^ *d) & 0xff;
-#ifdef CRC32_AVR_FLASH_TABLE
+#ifdef ARDUINO_ARCH_AVR
         crc = (pgm_read_dword(crc_table + tbl_idx) ^ (crc >> 8)) & 0xffffffff;
 #else
         crc = (crc_table[tbl_idx] ^ (crc >> 8)) & 0xffffffff;

--- a/src/crc.cpp
+++ b/src/crc.cpp
@@ -16,13 +16,17 @@
 #include "crc.h"     /* include the header file generated with pycrc */
 #include <stdlib.h>
 #include <stdint.h>
-
-
-
+#ifdef CRC32_AVR_FLASH_TABLE
+#include <avr/pgmspace.h>
+#endif
 /**
  * Static table used for the table_driven implementation.
  */
+#ifdef CRC32_AVR_FLASH_TABLE
+static const PROGMEM crc_t crc_table[256] = {
+#else
 static const crc_t crc_table[256] = {
+#endif
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
     0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
     0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
@@ -65,7 +69,11 @@ crc_t crc_update(crc_t crc, const void *data, size_t data_len)
 
     while (data_len--) {
         tbl_idx = (crc ^ *d) & 0xff;
+#ifdef CRC32_AVR_FLASH_TABLE
+        crc = (pgm_read_dword(crc_table + tbl_idx) ^ (crc >> 8)) & 0xffffffff;
+#else
         crc = (crc_table[tbl_idx] ^ (crc >> 8)) & 0xffffffff;
+#endif
         d++;
     }
     return crc & 0xffffffff;

--- a/src/crc.h
+++ b/src/crc.h
@@ -1,3 +1,4 @@
+#define CRC32_AVR_FLASH_TABLE // reduces my test to 6322/430, else 6328/1454
 /**
  * \file
  * Functions and types for CRC checks.

--- a/src/crc.h
+++ b/src/crc.h
@@ -1,4 +1,3 @@
-#define CRC32_AVR_FLASH_TABLE // reduces my test to 6322/430, else 6328/1454
 /**
  * \file
  * Functions and types for CRC checks.


### PR DESCRIPTION
My Nanos have 2K of RAM, and this uses over half of it. 
I have added an option (#define CRC32_AVR_FLASH_TABLE) that shifts crc_table into AVR Flash memory, saves 1K of RAM and a few bytes of Flash. 
It seems to test OK, and save memory.
